### PR TITLE
Set NFS V3 Driver & Broker to be configurable with whitelist config options by Bosh Operator

### DIFF
--- a/jobs/nfsbroker/spec
+++ b/jobs/nfsbroker/spec
@@ -47,3 +47,19 @@ properties:
   nfsbroker.db_ca_cert:
     default: ""
     description: "(optional) CA Cert to verify SSL connection, if not include, connection will be plain"
+  nfsbroker.allowed-in-source:
+    description: "Comma separated list of white-listed options that may be configured in supported in the mount_config.source URL query params. If a non-white-listed option is received from a user as arbitrary params, then the broker will reject the user request."
+    example: "uid,gid"
+    default: "uid,gid"
+  nfsbroker.default-in-source:
+    description: "Comma separated list of default values for options in the mount_config.source URL query params, formatted as 'option:default'. If an option is not specified in the provisioning arbitrary params, or the option is not white-listed, then the specified default value will be applied."
+    example: "uid:1000,gid:1000"
+    default: ""
+  nfsbroker.allowed-in-mount:
+    description: "Comma separated list of white-listed options that may be configured in supported in the mount_config options. If a non-white-listed option is received from a user as arbitrary params, then the broker will reject the user request."
+    example: "allow_root,allow_other,nfs_uid,nfs_gid,auto_cache,fsname"
+    default: "auto_cache"
+  nfsbroker.default-in-mount:
+    description: "Comma separated list default values for options that may be configured in the mount_config options, formatted as 'option:default'. If an option is not specified in the binding arbitrary params, or the option is not white-listed, then the specified default value will be applied."
+    example: "allow_root:false,allow_other:false,nfs_uid:2000,nfs_gid:2000,auto_cache:false"
+    default: "auto_cache:true"

--- a/jobs/nfsbroker/templates/ctl.erb
+++ b/jobs/nfsbroker/templates/ctl.erb
@@ -41,6 +41,10 @@ case $1 in
       --dbPort="<%= p("nfsbroker.db_port") %>" \
       --dbName="<%= p("nfsbroker.db_name") %>" \
       --dbCACert="<%= p("nfsbroker.db_ca_cert") %>" \
+      --allowed-in-source="<%= p("nfsbroker.allowed-in-source") %>" \
+      --default-in-source="<%= p("nfsbroker.default-in-source") %>" \
+      --allowed-in-mount="<%= p("nfsbroker.allowed-in-mount") %>" \
+      --default-in-mount="<%= p("nfsbroker.default-in-mount") %>" \
       >> $LOG_DIR/nfsbroker.stdout.log \
       2>> $LOG_DIR/nfsbroker.stderr.log
 

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -28,3 +28,19 @@ properties:
  nfsv3driver.disable:
    description: "disable nfsv3driver"
    default: false
+ nfsv3driver.allowed-in-source:
+   description: "Comma separated list of white-listed options that may be configured in supported in the mount_config.source URL query params"
+   example: "uid,gid,auto-traverse-mounts,dircache"
+   default: "uid,gid"
+ nfsv3driver.default-in-source:
+   description: "Comma separated list of default values for options in the source URL query params, formatted as 'option:default'. If an option is not specified in the volume mount, or the option is not white-listed, then the specified default value will be applied."
+   example: "uid:1000,gid=1000,auto-traverse-mounts=1"
+   default: ""
+ nfsv3driver.allowed-in-mount:
+   description: "Comma separated list of white-listed options that may be accepted in the mount_config options. Note a specific 'sloppy_mount:true' volume option tells the driver to ignore non-white-listed options, while a 'sloppy_mount:false' tells the driver to fail fast instead when receiving a non-white-listed option."
+   example: "allow_root,allow_other,nfs_uid,nfs_gid,auto_cache,sloppy_mount,fsname"
+   default: "auto_cache"
+ nfsv3driver.default-in-mount:
+   description: "Comma separated list default values for options that may be configured in the mount_config options, formatted as 'option:default'. If an option is not specified in the volume mount, or the option is not white-listed, then the specified default value will be used instead."
+   example: "allow_root:false,allow_other:false,nfs_uid:2000,nfs_gid:2000,auto_cache:true,sloppy_mount:true"
+   default: "auto_cache:true"

--- a/jobs/nfsv3driver/templates/ctl.erb
+++ b/jobs/nfsv3driver/templates/ctl.erb
@@ -44,6 +44,10 @@ case $1 in
       --driversPath="<%= p("nfsv3driver.driver_path") %>" \
       --mountDir="<%= p("nfsv3driver.cell_mount_path") %>" \
       --logLevel="<%= p("nfsv3driver.log_level") %>" \
+      --allowed-in-source="<%= p("nfsv3driver.allowed-in-source") %>" \
+      --default-in-source="<%= p("nfsv3driver.default-in-source") %>" \
+      --allowed-in-mount="<%= p("nfsv3driver.allowed-in-mount") %>" \
+      --default-in-mount="<%= p("nfsv3driver.default-in-mount") %>" \
       >> $LOG_DIR/nfsv3driver.stdout.log \
       2>> $LOG_DIR/nfsv3driver.stderr.log
 


### PR DESCRIPTION
Implements https://github.com/cloudfoundry-incubator/nfsv3driver/issues/2

# Linked Submodule 
  * Need to bump NFS V3 Driver to version proposed in https://github.com/cloudfoundry-incubator/nfsv3driver/pull/3
  * Need to bump NFS Broker to version proposed in https://github.com/cloudfoundry-incubator/nfsbroker/pull/2

# NFS V3 Driver Jobs
  * add properties : 
    * nfsv3driver.allowed-in-source with default value : uid,gid
    * nfsv3driver.default-in-source with default value : \<none\>
    * nfsv3driver.allowed-in-mount with default value: auto_cache
    * nfsv3driver.default-in-mount with default value: auto_cache=true

# NFS Broker Jobs
  * add properties: 
    * nfsbroker.allowed-in-source with default value : uid,gid
    * nfsbroker.default-in-source with default value : \<none\>
    * nfsbroker.allowed-in-mount with default value: auto_cache
    * nfsbroker.default-in-mount with default value: auto_cache=true
