### PR TITLE
nfsbrokerpush can find database address from a link

### DIFF
--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -10,6 +10,11 @@ packages:
   - golang-nfsvolume
   - cf_cli
 
+consumes:
+  - name: database
+    type: database
+    optional: true
+
 properties:
   nfsbrokerpush.domain:
     description: 'Cloud Foundry System Domain'

--- a/jobs/nfsbrokerpush/templates/manifest.yml.erb
+++ b/jobs/nfsbrokerpush/templates/manifest.yml.erb
@@ -1,4 +1,12 @@
 ---
+<%
+  database_host = nil
+  if_p('properties.nfsbrokerpush.db.host') do |host|
+    database_host = host
+  end.else do
+    database_host = link('database').instances[0].address
+  end
+%>
   buildpack: binary_buildpack
   domain: "<%= properties.nfsbrokerpush.app_domain %>"
   env:
@@ -9,7 +17,7 @@
     PASSWORD: "<%= properties.nfsbrokerpush.password %>"
     LOGLEVEL: info
     DBDRIVERNAME: "<%= properties.nfsbrokerpush.db.driver %>"
-    DBHOST: "<%= properties.nfsbrokerpush.db.host %>"
+    DBHOST: "<%= database_host %>"
     DBPORT: "<%= properties.nfsbrokerpush.db.port %>"
     DBNAME: "<%= properties.nfsbrokerpush.db.name %>"
     DB_USERNAME: "<%= properties.nfsbrokerpush.db.username %>"


### PR DESCRIPTION
By (optionally) consuming a database link, deployment manifests
do not need to specify explicit database addresses in their
manifest, which allows the manifest to be simpler and more
automatable.

This currently only looks for address because that is the
only property consistent in database links. When database links
begin providing more-comprehensive properties, the consumption
can be updated.